### PR TITLE
SAGE-1070 update pywaggle

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-https://github.com/waggle-sensor/pywaggle/archive/v0.40.5.zip
+waggle @ https://github.com/waggle-sensor/pywaggle/releases/download/0.46.2/waggle-0.46.2-py3-none-any.whl
 pyserial


### PR DESCRIPTION
This update is required for this plugin to work when run with a custom plugin name and to get device metadata.