### PR TITLE
[Sage-1220] Split node and beehive publishing intervals.

### DIFF
--- a/main.py
+++ b/main.py
@@ -61,12 +61,19 @@ def request_sample(dev: serial.Serial) -> str:
 
 
 publish_names = {
-    "Acc": "env.raingauge.acc",
+    # "Acc": "env.raingauge.acc", # NOT PUBLISHING
     "EventAcc": "env.raingauge.event_acc",
     "TotalAcc": "env.raingauge.total_acc",
     "RInt": "env.raingauge.rint",
 }
 
+# We are not publishing the Acc values for the following reasons:
+#
+# 1. We believe is is more accurate for users who want accumulation
+#    in some interval to take the diff of the first and last TotalAcc.
+#
+# 2. The scale and meaning of Acc is sampling rate dependent and would
+#    require looking at two samples anyway.
 
 def start_publishing(args, plugin, dev):
     """

--- a/main.py
+++ b/main.py
@@ -1,9 +1,10 @@
 import argparse
 import serial
-import time
 import parse
 import logging
-import waggle.plugin as plugin
+import sched
+import time
+from waggle.plugin import Plugin
 
 
 def validate_response(dev: serial.Serial, test) -> str:
@@ -67,11 +68,68 @@ publish_names = {
 }
 
 
+def start_publishing(args, plugin, dev):
+    """
+    start_publishing initializes the raingauge and begins sampling and publishing data
+    """
+    # initialize the raingauge
+    try:
+        logging.info("set to polling mode")
+        set_mode(dev, "p")
+    except:
+        pass
+    try:
+        logging.info("set to high precision")
+        set_mode(dev, "h")
+    except:
+        pass
+    try:
+        logging.info("set to metric mode")
+        set_mode(dev, "m")
+    except:
+        pass
+
+    sch = sched.scheduler(time.time, time.sleep)
+
+    def sample_and_publish_task(scope, delay):
+        sch.enter(delay, 0, sample_and_publish_task, kwargs={"scope": scope, "delay": delay})
+
+        logging.info("requesting sample for scope %s", scope)
+        sample = request_sample(dev)
+        values = parse.parse_values(sample)
+        logging.info("read values %s", values)
+
+        # publish each value in sample
+        for key, name in publish_names.items():
+            try:
+                value = values[key]
+            except KeyError:
+                continue
+            plugin.publish(name, value=value, scope=scope)
+
+    # setup and run publishing schedule
+    if args.node_publish_interval > 0:
+        sch.enter(0, 0, sample_and_publish_task, kwargs={
+            "scope": "node",
+            "delay": args.node_publish_interval,
+        })
+
+    if args.beehive_publish_interval > 0:
+        sch.enter(0, 0, sample_and_publish_task, kwargs={
+            "scope": "beehive",
+            "delay": args.beehive_publish_interval,
+        })
+
+    sch.run()
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--debug", action="store_true", help="enable debug logs")
     parser.add_argument("--device", default="/dev/ttyUSB0", help="serial device to use")
-    parser.add_argument("--rate", default=30.0, type=float, help="sampling rate")
+    parser.add_argument("--baudrate", default=9600, type=int, help="baudrate to use")
+    parser.add_argument("--node-publish-interval", default=1.0, type=float, help="interval to publish data to node")
+    parser.add_argument("--beehive-publish-interval", default=30.0, type=float, help="interval to publish data to beehive")
     args = parser.parse_args()
 
     logging.basicConfig(
@@ -80,41 +138,8 @@ def main():
         datefmt="%Y/%m/%d %H:%M:%S",
     )
 
-    plugin.init()
-
-    with serial.Serial(args.device, baudrate=9600, timeout=3.0) as dev:
-        # initialize the raingauge
-        try:
-            logging.info("set to polling mode")
-            set_mode(dev, "p")
-        except:
-            pass
-        try:
-            logging.info("set to high precision")
-            set_mode(dev, "h")
-        except:
-            pass
-        try:
-            logging.info("set to metric mode")
-            set_mode(dev, "m")
-        except:
-            pass
-
-        while True:
-            time.sleep(args.rate)
-
-            logging.info("requesting sample")
-            sample = request_sample(dev)
-            values = parse.parse_values(sample)
-            logging.info("read values %s", values)
-
-            # publish each value in sample
-            for key, name in publish_names.items():
-                try:
-                    value = values[key]
-                except KeyError:
-                    continue
-                plugin.publish(name, value=value)
+    with Plugin() as plugin, serial.Serial(args.device, baudrate=args.baudrate, timeout=3.0) as dev:
+        start_publishing(args, plugin, dev)
 
 
 if __name__ == "__main__":

--- a/main.py
+++ b/main.py
@@ -128,8 +128,8 @@ def main():
     parser.add_argument("--debug", action="store_true", help="enable debug logs")
     parser.add_argument("--device", default="/dev/ttyUSB0", help="serial device to use")
     parser.add_argument("--baudrate", default=9600, type=int, help="baudrate to use")
-    parser.add_argument("--node-publish-interval", default=1.0, type=float, help="interval to publish data to node")
-    parser.add_argument("--beehive-publish-interval", default=30.0, type=float, help="interval to publish data to beehive")
+    parser.add_argument("--node-publish-interval", default=1.0, type=float, help="interval to publish data to node (negative values disable node publishing)")
+    parser.add_argument("--beehive-publish-interval", default=30.0, type=float, help="interval to publish data to beehive (negative values disable beehive publishing)")
     args = parser.parse_args()
 
     logging.basicConfig(

--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ import parse
 import logging
 import sched
 import time
-from waggle.plugin import Plugin
+from waggle.plugin import Plugin, get_timestamp
 
 
 def validate_response(dev: serial.Serial, test) -> str:
@@ -105,9 +105,10 @@ def start_publishing(args, plugin, dev):
         })
 
         logging.info("requesting sample for scope %s", scope)
+        timestamp = get_timestamp()
         sample = request_sample(dev)
         values = parse.parse_values(sample)
-        logging.info("read values %s", values)
+        logging.debug("read values %s", values)
 
         # publish each value in sample
         for key, name in publish_names.items():
@@ -115,7 +116,8 @@ def start_publishing(args, plugin, dev):
                 value = values[key]
             except KeyError:
                 continue
-            plugin.publish(name, value=value, scope=scope)
+            logging.info("publishing %s %s", name, value)
+            plugin.publish(name, value=value, scope=scope, timestamp=timestamp)
 
     # setup and run publishing schedule
     if args.node_publish_interval > 0:

--- a/main.py
+++ b/main.py
@@ -92,7 +92,10 @@ def start_publishing(args, plugin, dev):
     sch = sched.scheduler(time.time, time.sleep)
 
     def sample_and_publish_task(scope, delay):
-        sch.enter(delay, 0, sample_and_publish_task, kwargs={"scope": scope, "delay": delay})
+        sch.enter(delay, 0, sample_and_publish_task, kwargs={
+            "scope": scope,
+            "delay": delay,
+        })
 
         logging.info("requesting sample for scope %s", scope)
         sample = request_sample(dev)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-waggle @ https://github.com/waggle-sensor/pywaggle/releases/download/0.46.2/waggle-0.46.2-py3-none-any.whl
+pywaggle==0.52.*
 pyserial

--- a/simulate.py
+++ b/simulate.py
@@ -1,0 +1,51 @@
+import argparse
+import logging
+from main import start_publishing
+from waggle.plugin import Plugin
+from random import uniform
+
+
+class MockRaingauge:
+
+    def __init__(self):
+        self.resp = []
+    
+    def write(self, b):
+        cmd = b.strip().lower()
+        if cmd == b"p":
+            self.resp.append("p\n")
+        elif cmd == b"h":
+            self.resp.append("h\n")
+        elif cmd == b"m":
+            self.resp.append("m\n")
+        elif cmd == b"r":
+            self.resp.append(f"Acc  {uniform(0, 2):.2f} mm, EventAcc  {uniform(0, 2):.2f} mm, TotalAcc  {uniform(0, 2):.2f} mm, RInt  {uniform(0, 2):.2f} mmph\n".encode())
+        return len(b)
+
+    def readline(self):
+        if len(self.resp) == 0:
+            return b""
+        b = self.resp[0]
+        self.resp.pop(0)
+        return b
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--debug", action="store_true", help="enable debug logs")
+    parser.add_argument("--node-publish-interval", default=1.0, type=float, help="interval to publish data to node")
+    parser.add_argument("--beehive-publish-interval", default=30.0, type=float, help="interval to publish data to beehive")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.debug else logging.INFO,
+        format="%(asctime)s %(message)s",
+        datefmt="%Y/%m/%d %H:%M:%S",
+    )
+
+    with Plugin() as plugin:
+        start_publishing(args, plugin, MockRaingauge())
+
+
+if __name__ == "__main__":
+    main()

--- a/simulate.py
+++ b/simulate.py
@@ -9,7 +9,7 @@ class MockRaingauge:
 
     def __init__(self):
         self.resp = []
-    
+
     def write(self, b):
         cmd = b.strip().lower()
         if cmd == b"p":
@@ -34,8 +34,8 @@ class MockRaingauge:
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--debug", action="store_true", help="enable debug logs")
-    parser.add_argument("--node-publish-interval", default=1.0, type=float, help="interval to publish data to node")
-    parser.add_argument("--beehive-publish-interval", default=30.0, type=float, help="interval to publish data to beehive")
+    parser.add_argument("--node-publish-interval", default=1.0, type=float, help="interval to publish data to node (negative values disable node publishing)")
+    parser.add_argument("--beehive-publish-interval", default=30.0, type=float, help="interval to publish data to beehive (negative values disable beehive publishing)")
     args = parser.parse_args()
 
     logging.basicConfig(

--- a/simulate.py
+++ b/simulate.py
@@ -13,11 +13,11 @@ class MockRaingauge:
     def write(self, b):
         cmd = b.strip().lower()
         if cmd == b"p":
-            self.resp.append("p\n")
+            self.resp.append(b"p\n")
         elif cmd == b"h":
-            self.resp.append("h\n")
+            self.resp.append(b"h\n")
         elif cmd == b"m":
-            self.resp.append("m\n")
+            self.resp.append(b"m\n")
         elif cmd == b"r":
             self.resp.append(f"Acc  {uniform(0, 2):.2f} mm, EventAcc  {uniform(0, 2):.2f} mm, TotalAcc  {uniform(0, 2):.2f} mm, RInt  {uniform(0, 2):.2f} mmph\n".encode())
         return len(b)

--- a/simulate.py
+++ b/simulate.py
@@ -23,6 +23,7 @@ class MockRaingauge:
         return len(b)
 
     def readline(self):
+        """readline returns the first queued up response or empty bytes to simulate timing out"""
         if len(self.resp) == 0:
             return b""
         b = self.resp[0]


### PR DESCRIPTION
This PR allow the rain gauge plugin to publish data to the node and beehive at different intervals.

These intervals are specified with the new `--node-publish-interval` and `--beehive-publish-interval` flags, which replace the `--rate` flag.

Note: These two sampling schedules are logically independent of each other. No attempt is made to share a common sample if the timing _happens to coincide_.
